### PR TITLE
Prevent hook from triggering nested task generation.

### DIFF
--- a/pirate_add_shift_recurrence.py
+++ b/pirate_add_shift_recurrence.py
@@ -18,6 +18,7 @@ def is_new_local_recurrence_child_task(task):
         return True
 
 tw = TaskWarrior(data_location=os.path.dirname(os.path.dirname(sys.argv[0])))
+tw.config.update(dict(recurrence="no"))
 
 def hook_shift_recurrence(task):
     if is_new_local_recurrence_child_task(task):


### PR DESCRIPTION
It seems you lost this line when you rewrote the hook to use taskpirate.
