### PR TITLE
Get task by ['parent']['uuid']

### DIFF
--- a/pirate_add_shift_recurrence.py
+++ b/pirate_add_shift_recurrence.py
@@ -22,7 +22,7 @@ tw.overrides.update(dict(recurrence="no", hooks="no"))
 
 def hook_shift_recurrence(task):
     if is_new_local_recurrence_child_task(task):
-        parent = tw.tasks.get(uuid=task['parent'])
+        parent = tw.tasks.get(uuid=task['parent']['uuid'])
         parent_due_shift = task['due'] - parent['due']
         for attr in time_attributes:
             if parent[attr]:


### PR DESCRIPTION
Currently this hook produces the following traceback:

``` python
Traceback (most recent call last):
  File "/Users/zax/annex/task/hooks/on-add-pirate", line 41, in <module>
    hook(task)
  File "/Users/zax/annex/task/hooks/shift-all-recurrence/pirate_add_shift_recurrence.py", line 26, in hook_shift_recurrence
    parent = tw.tasks.get(uuid=task['parent'])
  File "/usr/local/lib/python2.7/site-packages/tasklib/task.py", line 523, in get
    clone = self.filter(**kwargs)
  File "/usr/local/lib/python2.7/site-packages/tasklib/task.py", line 515, in filter
    clone.filter_obj.add_filter_param(key, value)
  File "/usr/local/lib/python2.7/site-packages/tasklib/filters.py", line 53, in add_filter_param
    value = self._normalize(attribute_key, value)
  File "/usr/local/lib/python2.7/site-packages/tasklib/serializing.py", line 69, in _normalize
    return normalize_func(value)
  File "/usr/local/lib/python2.7/site-packages/tasklib/serializing.py", line 252, in normalize_uuid
    "not: {}".format(value))
ValueError: UUID must be a valid non-empty string, not: LazyUUIDTask: 0455ea04-ee84-44ab-8678-56a6a3eb030a
```

This change seems to resolve the issue.
