### PR TITLE
Delete old installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,6 @@ Install
 Note: This hook has been rewritten to leverage taskpirate, for greater hook efficiency.
 Please see https://github.com/tbabej/taskpirate for instructions. Don't worry, it's straightforward.
 
-```
-git clone https://github.com/tbabej/taskwarrior-shift-all-recurrence-hook.git
-cp taskwarrior-shift-all-recurrence-hook/on-* ~/.task/hooks/
-```
-
-This hook leverages tasklib, so you need to install that too:
-
-```
-pip install tasklib
-```
-
 Use case
 --------
 


### PR DESCRIPTION
I guess what I removed are old instructions since those files are gone and the instructions are at https://github.com/tbabej/taskpirate.